### PR TITLE
Added pitched-memory support and implemented denoise_device_image()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,19 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # The following lines build the main executable.
-add_executable(bm3d
+#add_executable(bm3d
+#	include/CImg.h
+#	include/stopwatch.hpp
+#	include/indices.cuh
+#	include/params.hpp
+#	include/bm3d.hpp
+#	src/filtering.cu
+#	src/blockmatching.cu
+#	src/dct8x8.cu
+#	src/main_nodisplay.cpp
+#)
+
+add_library(bm3d
 	include/CImg.h
 	include/stopwatch.hpp
 	include/indices.cuh
@@ -19,7 +31,6 @@ add_executable(bm3d
 	src/filtering.cu
 	src/blockmatching.cu
 	src/dct8x8.cu
-	src/main_nodisplay.cpp
 )
 
 target_link_libraries(bm3d cufft cudart png)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,28 +9,33 @@ include_directories(
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# The following lines build the main executable.
-#add_executable(bm3d
-#	include/CImg.h
-#	include/stopwatch.hpp
-#	include/indices.cuh
-#	include/params.hpp
-#	include/bm3d.hpp
-#	src/filtering.cu
-#	src/blockmatching.cu
-#	src/dct8x8.cu
-#	src/main_nodisplay.cpp
-#)
+option(BUILD_EXE "Build executable" ON)
 
-add_library(bm3d
-	include/CImg.h
-	include/stopwatch.hpp
-	include/indices.cuh
-	include/params.hpp
-	include/bm3d.hpp
-	src/filtering.cu
-	src/blockmatching.cu
-	src/dct8x8.cu
-)
+if(BUILD_EXE)
+	# The following lines build the main executable.
+	add_executable(bm3d
+		include/CImg.h
+		include/stopwatch.hpp
+		include/indices.cuh
+		include/params.hpp
+		include/bm3d.hpp
+		src/filtering.cu
+		src/blockmatching.cu
+		src/dct8x8.cu
+		src/main_nodisplay.cpp
+	)
+else()
+	add_library(bm3d
+		include/CImg.h
+		include/stopwatch.hpp
+		include/indices.cuh
+		include/params.hpp
+		include/bm3d.hpp
+		src/filtering.cu
+		src/blockmatching.cu
+		src/dct8x8.cu
+	)
+endif(BUILD_EXE)
+unset(BUILD_EXE CACHE)
 
 target_link_libraries(bm3d cufft cudart png)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ All the image formats supported by the Cimg library.
 For users that have convert or gm installed, it supports most of the image formats. Otherwise we recommend to use the .bmp format.
 
 
-Usage:
+## Usage
+
+### Executable
 
 1. Download the code package and extract it. Go to that directory. 
 
@@ -46,7 +48,7 @@ Options:
 - quiet - no information about the state of processing is displayed
 - ReferenceImage - if provided, computes and prints PSNR between the ReferenceImage and DenoisedImage
 
-Example of gray-scale denoising by the fisrt step of BM3D:
+Example of gray-scale denoising by the first step of BM3D:
 ```
 ./bm3d lena_20.png lena_den.png 20
 ```
@@ -58,6 +60,41 @@ Example of grayscale denoising by both steps of BM3D with PSNR computation:
 ```
 ./bm3d lena_25.png lena_den.png 25 nocolor twostep quiet lena.png
 ``` 
+
+### Library
+
+By passing the option `BUILD_EXE=OFF` to CMake, the implementation can be build as a library to be included in other projects.
+For using the implementation within another project, the following function is provided:
+
+```
+#include "bm3d.hpp"
+
+void denoise_device_image(
+    const std::vector<uchar*> & d_noisy_image,
+    const std::vector<uchar*> & d_denoised_image,
+    const size_t pitch,
+    const int width,
+    const int height,
+    const int channels,
+    const uint* sigma,
+    const bool two_step
+)
+```
+
+where\
+\
+`d_noisy_image` is a vector of pointers to each channel of the noisy image,\
+`d_denoised_image` is a vector of pointers to each channel of the filtered image,\
+`pitch` specifies the pitch of the images `total bytes per row / sizeof(uchar)`,\
+`width` specifies the width of the images,
+`height` specifies the height of the images,
+`channels` specifies the number of channels,
+`sigma` specifies the BM3D sigma parameter,
+`two_step` specifies whether to process both steps of the BM3D method.
+
+It should be noted that both images must be allocated in GPU memory.
+
+
 # Citation
 If you find this implementation useful please cite the following paper in your work:
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ void denoise_device_image(
 )
 ```
 
-where\
-\
+where
+
 `d_noisy_image` is a vector of **device** pointers to each channel of the noisy image,\
 `d_denoised_image` is a vector of **device** pointers to each channel of the filtered image,\
 `pitch` specifies the [pitch of the images](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#device-memory) as `total bytes per row / sizeof(uchar)`,\
@@ -90,7 +90,7 @@ where\
 `height` specifies the height of the images,\
 `channels` specifies the number of channels,\
 `sigma` specifies the BM3D sigma parameter, and\
-`two_step` specifies whether to process both steps of the BM3D method.\
+`two_step` specifies whether to process both steps of the BM3D method.
 
 It should be noted that both images must be allocated in GPU memory before this function is called.
 

--- a/README.md
+++ b/README.md
@@ -83,16 +83,16 @@ void denoise_device_image(
 
 where\
 \
-`d_noisy_image` is a vector of pointers to each channel of the noisy image,\
-`d_denoised_image` is a vector of pointers to each channel of the filtered image,\
-`pitch` specifies the pitch of the images `total bytes per row / sizeof(uchar)`,\
-`width` specifies the width of the images,
-`height` specifies the height of the images,
-`channels` specifies the number of channels,
-`sigma` specifies the BM3D sigma parameter,
-`two_step` specifies whether to process both steps of the BM3D method.
+`d_noisy_image` is a vector of **device** pointers to each channel of the noisy image,\
+`d_denoised_image` is a vector of **device** pointers to each channel of the filtered image,\
+`pitch` specifies the [pitch of the images](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#device-memory) as `total bytes per row / sizeof(uchar)`,\
+`width` specifies the width of the images,\
+`height` specifies the height of the images,\
+`channels` specifies the number of channels,\
+`sigma` specifies the BM3D sigma parameter, and\
+`two_step` specifies whether to process both steps of the BM3D method.\
 
-It should be noted that both images must be allocated in GPU memory.
+It should be noted that both images must be allocated in GPU memory before this function is called.
 
 
 # Citation

--- a/include/bm3d.hpp
+++ b/include/bm3d.hpp
@@ -168,8 +168,8 @@ private:
 	int h_reserved_channels;
 	bool h_reserved_two_step;
 	uint2 h_batch_size; 				//h_batch_size.x has to be divisible by properties.warpSize
-	size_t d_pitch_uchar;
-	size_t d_pitch_float;
+	size_t d_pitch_uchar; 				//bytes / sizeof(uchar)
+	size_t d_pitch_float; 				//bytes / sizeof(float)
 
 	//Denoising parameters
 	Params h_hard_params;
@@ -216,6 +216,7 @@ private:
 		for(auto & it : d_denoised_image) {
 			cuda_error_check(cudaMallocPitch((void**)&it, &d_pitch_uchar, byte_width, height));
 		}
+		d_pitch_uchar /= sizeof(uchar);
 
 		byte_width = width * sizeof(float);
 		for(auto & it : d_numerator) {
@@ -225,7 +226,7 @@ private:
 		for(auto & it : d_denominator) {
 			cuda_error_check(cudaMallocPitch((void**)&it, &d_pitch_float, byte_width, height));
 		}
-
+		d_pitch_float /= sizeof(float);
 	}
 
 	//Allocate device buffers dependent on image dimensions
@@ -242,7 +243,7 @@ private:
 		for(auto & it : d_denominator) {
 			cuda_error_check(cudaMallocPitch((void**)&it, &d_pitch_float, byte_width, height));
 		}
-
+		d_pitch_float /= sizeof(float);
 	}
 
 	//Creates an kaiser window (only for k = 8, alpha = 2.0) and copies it to the device.

--- a/include/bm3d.hpp
+++ b/include/bm3d.hpp
@@ -32,6 +32,7 @@
 
 extern "C" void run_block_matching(
 	const  uchar* __restrict image,
+	const size_t pitch,
 	ushort* stacks,
 	uint* num_patches_in_stack,
 	const uint2 image_dim,
@@ -46,6 +47,7 @@ extern "C" void run_block_matching(
 extern "C" void run_get_block(
 	const uint2 start_point,
 	const uchar* __restrict image,
+	const size_t pitch,
 	const ushort* __restrict stacks,
 	const uint* __restrict num_patches_in_stack,
 	float* patch_stack,
@@ -93,6 +95,7 @@ extern "C" void run_aggregate_block(
 	const float* __restrict kaiser_window,
 	float* numerator,
 	float* denominator,
+	const size_t num_denom_pitch,
 	const uint* __restrict num_patches_in_stack,
 	const uint2 image_dim,
 	const uint2 stacks_dim,
@@ -104,8 +107,10 @@ extern "C" void run_aggregate_block(
 extern "C" void run_aggregate_final(
 	const float* __restrict numerator,
 	const float* __restrict denominator,
+	const size_t num_denom_pitch,
 	const uint2 image_dim,
 	uchar* denoised_noisy_image,
+	const size_t image_pitch,
 	const dim3 num_threads,
 	const dim3 num_blocks
 );
@@ -163,6 +168,8 @@ private:
 	int h_reserved_channels;
 	bool h_reserved_two_step;
 	uint2 h_batch_size; 				//h_batch_size.x has to be divisible by properties.warpSize
+	size_t d_pitch_uchar;
+	size_t d_pitch_float;
 
 	//Denoising parameters
 	Params h_hard_params;
@@ -201,21 +208,22 @@ private:
 		d_numerator.resize(channels);
 		d_denominator.resize(channels);
 
-		int size = width * height;
+		size_t byte_width = width * sizeof(uchar);
 		for(auto & it : d_noisy_image) {
-			cuda_error_check( cudaMalloc((void**)&it, sizeof(uchar) * size) );
+			cuda_error_check(cudaMallocPitch((void**)&it, &d_pitch_uchar, byte_width, height));
 		}
 
 		for(auto & it : d_denoised_image) {
-			cuda_error_check( cudaMalloc((void**)&it, sizeof(uchar) * size) );
+			cuda_error_check(cudaMallocPitch((void**)&it, &d_pitch_uchar, byte_width, height));
 		}
 
+		byte_width = width * sizeof(float);
 		for(auto & it : d_numerator) {
-			cuda_error_check( cudaMalloc((void**)&it, sizeof(float) * size) );
+			cuda_error_check(cudaMallocPitch((void**)&it, &d_pitch_float, byte_width, height));
 		}
 
 		for(auto & it : d_denominator) {
-			cuda_error_check( cudaMalloc((void**)&it, sizeof(float) * size) );
+			cuda_error_check(cudaMallocPitch((void**)&it, &d_pitch_float, byte_width, height));
 		}
 
 	}
@@ -226,14 +234,13 @@ private:
 		d_numerator.resize(channels);
 		d_denominator.resize(channels);
 
-		int size = width * height;
-
+		const size_t byte_width = width * sizeof(float);
 		for(auto & it : d_numerator) {
-			cuda_error_check( cudaMalloc((void**)&it, sizeof(float) * size) );
+			cuda_error_check(cudaMallocPitch((void**)&it, &d_pitch_float, byte_width, height));
 		}
 
 		for(auto & it : d_denominator) {
-			cuda_error_check( cudaMalloc((void**)&it, sizeof(float) * size) );
+			cuda_error_check(cudaMallocPitch((void**)&it, &d_pitch_float, byte_width, height));
 		}
 
 	}
@@ -269,11 +276,10 @@ private:
 	//Copy image to device
 	void copy_device_image(const uchar * src_image, int width, int height, int channels)
 	{
-		size_t image_size = width * height;
-		for(int i = 0; i < channels; ++i) {
-			//Copy image to device
-			cuda_error_check( cudaMemcpy(d_noisy_image[i],src_image+i*image_size,image_size*sizeof(uchar),cudaMemcpyHostToDevice));
-		}
+		const size_t image_size = width * height;
+		const size_t h_pitch = width * sizeof(uchar);
+		for (unsigned char i = 0; i < channels; i++)
+			cuda_error_check(cudaMemcpy2D(d_noisy_image[i], d_pitch_uchar, src_image + i * image_size, h_pitch, h_pitch, height, cudaMemcpyHostToDevice));
 	}
 	
 	//Compute launch parameters for block-matching kernel
@@ -312,8 +318,15 @@ private:
 	/*
 	Launch first step of BM3D. It produces basic estimate in denoised_image arrays.
 	*/
-	void first_step(std::vector<uchar*> & d_noisy_image, std::vector<uchar*> & denoised_image, int width, int height, int channels, uint* sigma)
-	{	
+	void first_step(
+		const std::vector<uchar*> & d_noisy_image,
+		const std::vector<uchar*> & denoised_image,
+		const size_t pitch,
+		const int width,
+		const int height,
+		const int channels,
+		const uint* sigma
+	) {
 		//image dimensions
 		const uint2 image_dim = make_uint2(width,height);
 
@@ -374,6 +387,7 @@ private:
 				//Finds similar patches for each reference patch of a batch and stores them in d_stacks array
 				run_block_matching(
 					d_noisy_image[0],			// IN: Image	
+					pitch,						// IN: Pitch of image
 					d_stacks,					// OUT: Array of adresses of similar patches
 					d_num_patches_in_stack,		// OUT: Array containing numbers of these addresses
 					image_dim,					// IN: Image dimensions
@@ -400,6 +414,7 @@ private:
 					run_get_block(
 						start_point,				//IN: First reference patch of a batch
 						d_noisy_image[channel],		//IN: Image
+						pitch,						//IN: Pitch of image
 						d_stacks,					//IN: Array of adresses of similar patches
 						d_num_patches_in_stack,		//IN: Numbers of patches in 3D groups
 						d_gathered_stacks,			//OUT: Assembled 3D groups
@@ -482,6 +497,7 @@ private:
 						d_kaiser_window,			//IN: Kaiser window
 						d_numerator[channel],		//IN/OUT: Numerator aggregation buffer
 						d_denominator[channel],		//IN/OUT: Denominator aggregation buffer
+						d_pitch_float,				//IN: Pitch of numerator and denominator aggregation buffer
 						d_num_patches_in_stack,		//IN: Numbers of patches in 3D groups
 						image_dim,					//IN: Image dimensions
 						stacks_dim,					//IN: Dimensions limiting addresses of reference patches
@@ -505,8 +521,10 @@ private:
 			run_aggregate_final(
 				d_numerator[channel],			//IN: Numerator aggregation buffer
 				d_denominator[channel],			//IN: Denominator aggregation buffer
+				d_pitch_float,					//IN: Pitch of numerator and denominator aggregation buffer
 				image_dim,						//IN: Image dimensions
 				denoised_image[channel],		//OUT: Image estimate
+				pitch,							//IN: Pitch of image estimate
 				num_threads_f,					//CUDA: Threads in block
 				num_blocks_f 					//CUDA: Blocks in grid
 			);
@@ -530,11 +548,18 @@ private:
 
 	void first_step(std::vector<uchar*> & denoised_image, int width, int height, int channels, uint* sigma)
 	{
-		first_step(this->d_noisy_image, denoised_image, width, height, channels, sigma);
+		first_step(d_noisy_image, denoised_image, d_pitch_uchar, width, height, channels, sigma);
 	}
 
-	void second_step(std::vector<uchar*> & d_noisy_image, std::vector<uchar*> & denoised_image, int width, int height, int channels, uint* sigma)
-	{	
+	void second_step(
+		const std::vector<uchar*> & d_noisy_image,
+		const std::vector<uchar*> & denoised_image,
+		const size_t pitch,
+		const int width,
+		const int height,
+		const int channels,
+		const uint* sigma
+	) {
 		//Image dimensions
 		const uint2 image_dim = make_uint2(width,height);
 
@@ -597,6 +622,7 @@ private:
 
 				run_block_matching(
 					denoised_image[0],		// IN: Image
+					pitch,					// IN: Pitch of image
 					d_stacks,				// OUT: Array of adresses of similar patches
 					d_num_patches_in_stack,	// OUT: Number of blocks on each adress
 					image_dim,				// IN: Image dimensions
@@ -623,6 +649,7 @@ private:
 					run_get_block(
 						start_point,				//IN: First reference patch of a batch
 						denoised_image[channel], 	//IN: Basic image estimate (produced by 1st step)
+						pitch,						//IN: Pitch of basic image estimate
 						d_stacks,					//IN: Array of adresses of similar patches
 						d_num_patches_in_stack,		//IN: Numbers of patches in 3D groups
 						d_gathered_stacks_basic,	//OUT: Assembled 3D groups
@@ -640,6 +667,7 @@ private:
 					run_get_block(
 						start_point,				//IN: First reference patch of a batch
 						d_noisy_image[channel],		//IN: Basic image estimate (produced by 1st step)
+						pitch,						//IN: Pitch of basic image estimate
 						d_stacks,					//IN: Array of adresses of similar patches
 						d_num_patches_in_stack,		//IN: Numbers of patches in 3D groups
 						d_gathered_stacks,			//OUT: Assembled 3D groups
@@ -731,6 +759,7 @@ private:
 						d_kaiser_window,		//IN: Kaiser window
 						d_numerator[channel],	//IN/OUT: Numerator aggregation buffer
 						d_denominator[channel],	//IN/OUT: Denominator aggregation buffer
+						d_pitch_float,			//IN: Pitch of numerator and aggregation buffer
 						d_num_patches_in_stack,	//IN: Numbers of patches in 3D groups
 						image_dim,				//IN: Image dimensions
 						stacks_dim,				//IN: Dimensions limiting addresses of reference patches
@@ -753,8 +782,10 @@ private:
 			run_aggregate_final(
 				d_numerator[channel],			//IN: Aggregation buffer
 				d_denominator[channel],			//IN: Aggregation buffer
+				d_pitch_float,					//IN: Pitch of aggregation buffers
 				image_dim,						//IN: Image dimensions
 				denoised_image[channel],		//OUT: Image estimate
+				pitch,							//IN: Pitch of image estimate
 				num_threads_f,
 				num_blocks_f 
 			);
@@ -777,21 +808,16 @@ private:
 
 	void second_step(std::vector<uchar*> & denoised_image, int width, int height, int channels, uint* sigma)
 	{
-		second_step(this->d_noisy_image, denoised_image, width, height, channels, sigma);
+		second_step(d_noisy_image, denoised_image, d_pitch_uchar, width, height, channels, sigma);
 	}
 
 	//Copy image from device to host
 	void copy_host_image(uchar * dst_image, int width, int height, int channels)
 	{
-		size_t image_size = width * height;
-		for (int channel = 0; channel < channels; ++channel)
-		{
-			cuda_error_check( cudaMemcpy(
-						dst_image+channel*image_size,		// Destination
-						d_denoised_image[channel],			// Source
-						image_size*sizeof(uchar),			// Size
-						cudaMemcpyDeviceToHost) );			// Copy direction
-		}
+		const size_t image_size = width * height;
+		const size_t h_pitch = width * sizeof(uchar);
+		for (unsigned char i = 0; i < channels; i++)
+			cuda_error_check(cudaMemcpy2D(dst_image + i * image_size, h_pitch, d_denoised_image[i], d_pitch_uchar, h_pitch, height, cudaMemcpyDeviceToHost));
 	}
 
 	//Free all buffers allocated on device that are dependent on 'denoising parameters'.
@@ -925,8 +951,16 @@ public:
 			std::cout << "Total time: " << total.getSeconds() << std::endl;
 	}
 
-	void denoise_device_image(std::vector<uchar*> & d_noisy_image, std::vector<uchar*> & d_denoised_image, int width, int height, int channels, uint* sigma, bool two_step)
-	{
+	void denoise_device_image(
+		const std::vector<uchar*> & d_noisy_image,
+		const std::vector<uchar*> & d_denoised_image,
+		const size_t pitch,
+		const int width,
+		const int height,
+		const int channels,
+		const uint* sigma,
+		const bool two_step
+	) {
 		Stopwatch total;
 		total.start();
 
@@ -942,7 +976,7 @@ public:
 
 		//1st denoising step
 		null_aggregation_buffers(width,height);
-		first_step(d_noisy_image, d_denoised_image, width, height, channels, sigma);
+		first_step(d_noisy_image, d_denoised_image, pitch, width, height, channels, sigma);
 
 		p1.stop();
 		if (_verbose)
@@ -954,7 +988,7 @@ public:
 			Stopwatch p2;
 			p2.start();
 			null_aggregation_buffers(width,height);
-			second_step(d_noisy_image, d_denoised_image, width, height, channels, sigma);
+			second_step(d_noisy_image, d_denoised_image, pitch, width, height, channels, sigma);
 			if (_verbose)
 				std::cout << "2nd step took: " << p2.getSeconds() << std::endl;
 		}

--- a/src/blockmatching.cu
+++ b/src/blockmatching.cu
@@ -128,10 +128,7 @@ void block_matching(
 		int sx = i % p_rectangle_width;
 		int sy = i / p_rectangle_width;
 		if (p_rectangle_start+sx >= image_dim.x) continue;
-		// HSTODO
-		// s_image_p[i] = image[idx2(p_rectangle_start+sx,p.y+sy,image_dim.x)];
-		//s_image_p[i] = image[idx2(p_rectangle_start + sx, p.y + sy, image_dim.x * pitch / sizeof(uchar))]; ??
-		s_image_p[i] = ((uchar*)((char*)image + (p.y + sy) * pitch))[p_rectangle_start + sx];
+		s_image_p[i] = image[(p.y + sy) * pitch + p_rectangle_start + sx];
 	}
 	
 	__syncthreads();
@@ -170,9 +167,7 @@ void block_matching(
 				uint dist = 0;
 				for(uint iy = 0; iy < params.k; ++iy)
 				{
-					// HSTODO
-					//dist += L2p2((int)s_image_p[ idx2(i, iy, p_rectangle_width) ], (int)image[ idx2(q_rectangle_start+i, q.y+iy, image_dim.x) ]);
-					dist += L2p2((int)s_image_p[ idx2(i, iy, p_rectangle_width) ], (int)((uchar*)((char*)image + (q.y + iy) * pitch))[q_rectangle_start + i]);
+					dist += L2p2((int)s_image_p[idx2(i, iy, p_rectangle_width)], (int)image[(q.y + iy) * pitch + q_rectangle_start + i]);
 				}
 				s_diff[i] = dist;
 			}

--- a/src/blockmatching.cu
+++ b/src/blockmatching.cu
@@ -74,6 +74,7 @@ Each thread process one reference patch. All the warps of a block process the sa
 __global__
 void block_matching(
 	const  uchar* __restrict image, //IN: Original image
+	const size_t pitch,				//IN: Pitch of original image
 	ushort* g_stacks, 				//OUT: For each reference patch contains addresses of similar patches (patch is adressed by top left corner) [..LOC_Y(sbyte)..|..LOC_X(sbyte)..]
 	uint* g_num_patches_in_stack,	//OUT: For each reference patch contains number of similar patches
 	const uint2 image_dim,			//IN: Image dimensions
@@ -127,7 +128,10 @@ void block_matching(
 		int sx = i % p_rectangle_width;
 		int sy = i / p_rectangle_width;
 		if (p_rectangle_start+sx >= image_dim.x) continue;
-		s_image_p[i] = image[idx2(p_rectangle_start+sx,p.y+sy,image_dim.x)];
+		// HSTODO
+		// s_image_p[i] = image[idx2(p_rectangle_start+sx,p.y+sy,image_dim.x)];
+		//s_image_p[i] = image[idx2(p_rectangle_start + sx, p.y + sy, image_dim.x * pitch / sizeof(uchar))]; ??
+		s_image_p[i] = ((uchar*)((char*)image + (p.y + sy) * pitch))[p_rectangle_start + sx];
 	}
 	
 	__syncthreads();
@@ -166,7 +170,9 @@ void block_matching(
 				uint dist = 0;
 				for(uint iy = 0; iy < params.k; ++iy)
 				{
-					dist += L2p2((int)s_image_p[ idx2(i, iy, p_rectangle_width) ], (int)image[ idx2(q_rectangle_start+i, q.y+iy, image_dim.x) ]);
+					// HSTODO
+					//dist += L2p2((int)s_image_p[ idx2(i, iy, p_rectangle_width) ], (int)image[ idx2(q_rectangle_start+i, q.y+iy, image_dim.x) ]);
+					dist += L2p2((int)s_image_p[ idx2(i, iy, p_rectangle_width) ], (int)((uchar*)((char*)image + (q.y + iy) * pitch))[q_rectangle_start + i]);
 				}
 				s_diff[i] = dist;
 			}
@@ -246,7 +252,8 @@ void block_matching(
 
 
 extern "C" void run_block_matching(
-	const  uchar* __restrict image, //Original image
+	const uchar* __restrict image,  //Original image
+	const size_t pitch,		        //Pitch of original image
 	ushort* stacks, 				//For each reference patch contains addresses of similar patches (patch is adressed by top left corner)
 	uint* num_patches_in_stack,		//For each reference patch contains number of similar patches
 	const uint2 image_dim,			//Image dimensions
@@ -260,6 +267,7 @@ extern "C" void run_block_matching(
 {
 	block_matching<<<num_blocks, num_threads,shared_memory_size>>>(
 		image,
+		pitch,
 		stacks,
 		num_patches_in_stack,
 		image_dim,

--- a/src/filtering.cu
+++ b/src/filtering.cu
@@ -293,14 +293,11 @@ void aggregate_final(
 	uint idy = blockIdx.y * blockDim.y + threadIdx.y;
 	if (idx >= image_dim.x || idy >= image_dim.y) return;
 
-	// HSTODO
-	// int value = lrintf(numerator[ idx2(idx,idy,image_dim.x) ] / denominator[ idx2(idx,idy,image_dim.x) ] );
-	int value = lrintf(((float*)((char*)numerator + idy * num_denom_pitch))[idx] / ((float*)((char*)denominator + idy * num_denom_pitch))[idx]);
+	const uint index = idy * num_denom_pitch / sizeof(float) + idx;
+	int value = lrintf(numerator[index] / denominator[index]);
 	if (value < 0) value = 0;
 	if (value > 255) value = 255;
-	// HSTODO
-	// image_o[ idx2(idx,idy,image_dim.x) ] = (uchar)value;
-	((uchar*)((char*)image_o + idy * image_pitch))[idx] = (uchar)value;
+	image_o[idy * image_pitch + idx] = (uchar)value;
 }
 
 

--- a/src/filtering.cu
+++ b/src/filtering.cu
@@ -271,7 +271,7 @@ void aggregate_block(
 		}
 
 		float value = ( patch_stack[ idx3(threadIdx.x, threadIdx.y, z, params.k, params.k) ]);
-		const uint idx = (outer_address.y + y + threadIdx.y) * num_denom_pitch / sizeof(float) + outer_address.x + x + threadIdx.x;
+		const uint idx = (outer_address.y + y + threadIdx.y) * num_denom_pitch + outer_address.x + x + threadIdx.x;
 		atomicAdd(numerator + idx, value * kaiser_value * wp);
 		atomicAdd(denominator + idx, kaiser_value * wp);
 	}
@@ -293,7 +293,7 @@ void aggregate_final(
 	uint idy = blockIdx.y * blockDim.y + threadIdx.y;
 	if (idx >= image_dim.x || idy >= image_dim.y) return;
 
-	const uint index = idy * num_denom_pitch / sizeof(float) + idx;
+	const uint index = idy * num_denom_pitch + idx;
 	int value = lrintf(numerator[index] / denominator[index]);
 	if (value < 0) value = 0;
 	if (value > 255) value = 255;

--- a/src/filtering.cu
+++ b/src/filtering.cu
@@ -115,6 +115,7 @@ __global__
 void get_block(
 		const uint2 start_point, 				//IN: first reference patch of a batch
 		const uchar* __restrict image,				//IN: image
+		const size_t pitch,							//IN: pitch of image
 		const ushort* __restrict stacks,				//IN: array of adresses of similar patches
 		const uint* __restrict g_num_patches_in_stack,		//IN: numbers of patches in 3D groups
 		float* patch_stack,					//OUT: assembled 3D groups
@@ -136,12 +137,16 @@ void get_block(
 
 	uint num_patches = g_num_patches_in_stack[ idx2(blockIdx.x, blockIdx.y, gridDim.x) ];
 	
-	patch_stack[ idx3(threadIdx.x, threadIdx.y, 0, params.k, params.k) ] = (float)(image[ idx2(outer_address.x+threadIdx.x, outer_address.y+threadIdx.y, image_dim.x)]);
+	// HSTODO
+	// patch_stack[ idx3(threadIdx.x, threadIdx.y, 0, params.k, params.k) ] = (float)(image[ idx2(outer_address.x+threadIdx.x, outer_address.y+threadIdx.y, image_dim.x)]);
+	patch_stack[ idx3(threadIdx.x, threadIdx.y, 0, params.k, params.k) ] = (float)((uchar*)((char*)image + (outer_address.y + threadIdx.y) * pitch))[outer_address.x + threadIdx.x];
 	for(uint i = 0; i < num_patches; ++i)
 	{
 		int x = (int)((signed char)(z_ptr[i] & 0xFF));
 		int y = (int)((signed char)((z_ptr[i] >> 8) & 0xFF));
-		patch_stack[ idx3(threadIdx.x, threadIdx.y, i+1, params.k, params.k) ] = (float)(image[ idx2(outer_address.x+x+threadIdx.x, outer_address.y+y+threadIdx.y, image_dim.x)]);
+		// HSTODO
+		// patch_stack[ idx3(threadIdx.x, threadIdx.y, i+1, params.k, params.k) ] = (float)(image[ idx2(outer_address.x+x+threadIdx.x, outer_address.y+y+threadIdx.y, image_dim.x)]);
+		patch_stack[ idx3(threadIdx.x, threadIdx.y, i+1, params.k, params.k) ] = (float)((uchar*)((char*)image + (outer_address.y + y + threadIdx.y) * pitch))[outer_address.x + x + threadIdx.x];
 	}
 }
 
@@ -237,6 +242,7 @@ void aggregate_block(
 	const float* __restrict kaiser_window,		//IN: kaiser window
 	float* numerator,				//IN/OUT: numerator aggregation buffer (have to be initialized to 0)
 	float* denominator,				//IN/OUT: denominator aggregation buffer (have to be initialized to 0)
+	const size_t num_denom_pitch,	//IN: pitch of numerator and denominator aggregation buffer
 	const uint* __restrict g_num_patches_in_stack,	//IN: numbers of patches in 3D groups
 	const uint2 image_dim,				//IN: image dimensions
 	const uint2 stacks_dim,				//IN: dimensions limiting addresses of reference patches
@@ -269,9 +275,12 @@ void aggregate_block(
 		}
 
 		float value = ( patch_stack[ idx3(threadIdx.x, threadIdx.y, z, params.k, params.k) ]);
-		int idx = idx2(outer_address.x + x + threadIdx.x, outer_address.y + y + threadIdx.y, image_dim.x);
-		atomicAdd(numerator + idx, value * kaiser_value * wp);
-		atomicAdd(denominator + idx, kaiser_value * wp);
+		// HSTODO
+		// int idx = idx2(outer_address.x + x + threadIdx.x, outer_address.y + y + threadIdx.y, image_dim.x);
+		// atomicAdd(numerator + idx, value * kaiser_value * wp);
+		// atomicAdd(denominator + idx, kaiser_value * wp);
+		atomicAdd(&((float*)((char*)numerator   + (outer_address.y + y + threadIdx.y) * num_denom_pitch))[outer_address.x + x + threadIdx.x], value * kaiser_value * wp);
+		atomicAdd(&((float*)((char*)denominator + (outer_address.y + y + threadIdx.y) * num_denom_pitch))[outer_address.x + x + threadIdx.x], kaiser_value * wp);
 	}
 }
 
@@ -282,17 +291,23 @@ __global__
 void aggregate_final(
 	const float* __restrict numerator,	//IN: numerator aggregation buffer
 	const float* __restrict denominator,	//IN: denominator aggregation buffer
+	const size_t num_denom_pitch,			//IN: pitch of numerator and denominator aggregation buffer
 	const uint2 image_dim,			//IN: image dimensions
-	uchar* image_o)				//OUT: image estimate
-{
+	uchar* image_o,				//OUT: image estimate
+	const size_t image_pitch	//IN: pitch of image estimate
+) {
 	uint idx = blockIdx.x * blockDim.x + threadIdx.x;
 	uint idy = blockIdx.y * blockDim.y + threadIdx.y;
 	if (idx >= image_dim.x || idy >= image_dim.y) return;
 
-	int value = lrintf(numerator[ idx2(idx,idy,image_dim.x) ] / denominator[ idx2(idx,idy,image_dim.x) ] );
+	// HSTODO
+	// int value = lrintf(numerator[ idx2(idx,idy,image_dim.x) ] / denominator[ idx2(idx,idy,image_dim.x) ] );
+	int value = lrintf(((float*)((char*)numerator + idy * num_denom_pitch))[idx] / ((float*)((char*)denominator + idy * num_denom_pitch))[idx]);
 	if (value < 0) value = 0;
 	if (value > 255) value = 255;
-	image_o[ idx2(idx,idy,image_dim.x) ] = (uchar)value;
+	// HSTODO
+	// image_o[ idx2(idx,idy,image_dim.x) ] = (uchar)value;
+	((uchar*)((char*)image_o + idy * image_pitch))[idx] = (uchar)value;
 }
 
 
@@ -384,6 +399,7 @@ void wiener_filtering(
 extern "C" void run_get_block(
 	const uint2 start_point,
 	const uchar* __restrict image,
+	const size_t pitch,
 	const ushort* __restrict stacks,
 	const uint* __restrict num_patches_in_stack,
 	float* patch_stack,
@@ -396,6 +412,7 @@ extern "C" void run_get_block(
 	get_block<<<num_blocks,num_threads>>>(
 		start_point,
 		image,
+		pitch,
 		stacks,
 		num_patches_in_stack,
 		patch_stack,
@@ -436,6 +453,7 @@ extern "C" void run_aggregate_block(
 	const float* __restrict kaiser_window,
 	float* numerator,
 	float* denominator,
+	const size_t num_denom_pitch,
 	const uint* __restrict num_patches_in_stack,
 	const uint2 image_dim,
 	const uint2 stacks_dim,
@@ -451,6 +469,7 @@ extern "C" void run_aggregate_block(
 		kaiser_window,
 		numerator,
 		denominator,
+		num_denom_pitch,
 		num_patches_in_stack,
 		image_dim,
 		stacks_dim,
@@ -461,8 +480,10 @@ extern "C" void run_aggregate_block(
 extern "C" void run_aggregate_final(
 	const float* __restrict numerator,
 	const float* __restrict denominator,
+	const size_t num_denom_pitch,
 	const uint2 image_dim,
 	uchar* denoised_image,
+	const size_t image_pitch,
 	const dim3 num_threads,
 	const dim3 num_blocks
 )
@@ -470,8 +491,10 @@ extern "C" void run_aggregate_final(
 	aggregate_final<<<num_blocks,num_threads>>>(
 		numerator,
 		denominator,
+		num_denom_pitch,
 		image_dim,
-		denoised_image
+		denoised_image,
+		image_pitch
 	);	
 }
 


### PR DESCRIPTION
I have added support for pitched memory and implemented the function `denoise_device_image()`, which can be used to filter images that are already in GPU memory.